### PR TITLE
Sugar-1402: Change node version and install git client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=linux/amd64 node:18-bullseye-slim
+FROM --platform=linux/amd64 node:23-bullseye-slim
 
-RUN apt-get update && apt-get install -y curl \
+RUN apt-get update && apt-get install -y curl git \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/


### PR DESCRIPTION
This pull request changes the Dockerfile to update the base image to` node:23-bullseye-slim` and install `git` client.

Related Ticket:
https://linear.app/partnerstack/issue/SUGAR-1402/investigate-auth-edge-release-failures-on-ci

Error from CircleCI
https://app.circleci.com/pipelines/github/partnerstack/auth-edge/77/workflows/da17555a-7b98-45ae-82e2-deddbb331f34/jobs/29

