### PR TITLE
Sugar-1402: Change CircleCI ubuntu version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
       docker_layer_caching: true
     steps:
       - checkout
@@ -21,7 +21,7 @@ jobs:
             docker push "partnerstack/cloudflare-wrangler:${CIRCLE_SHA1}"
   tag-and-release:
     machine:
-      image: ubuntu-2004:202104-01
+      image: ubuntu-2004:current
       docker_layer_caching: true
     steps:
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM --platform=linux/amd64 node:18-bullseye-slim
+FROM --platform=linux/amd64 node:23-bullseye-slim
 
-RUN apt-get update && apt-get install -y curl \
+RUN apt-get update && apt-get install -y curl git \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/


### PR DESCRIPTION
Ubuntu-2004 specified has being deprecated, this PR changes the version to use the current version.

**Error:**
```
Job was rejected because resource class large, image ubuntu-2004:202104-01 is not a valid resource class
```
https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

